### PR TITLE
fix: Correct discount logic - apply 10% to total instead of 50% to unit price

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,16 +5,14 @@ def main():
 def calculate_discount(price, quantity):
     """
     Calculates total price with a 10% discount if total > 1000.
-    Bug: It applies the discount to the unit price instead of the total price.
     """
     total = price * quantity
     if total > 1000:
-        # BUG: This reduces the unit price by 10% first, which is wrong.
-        return (price * 0.5) * quantity
+        # Apply 10% discount to the total (pay 90%)
+        return total * 0.9
     return total
 
 
 if __name__ == "__main__":
     main()
     print(calculate_discount(100, 5))
-

--- a/maintenance_log.md
+++ b/maintenance_log.md
@@ -1,0 +1,27 @@
+# Maintenance Log
+
+## 2026-04-30
+
+### Issue #1: Incorrect discount logic in calculate_discount function
+
+- **Issue ID:** #1
+- **Repository:** s0l0l0b0/demo-agent-project
+- **Status:** Fixed
+
+**Root Cause:**
+The `calculate_discount` function was incorrectly applying a 50% discount to the unit price (`price * 0.5 * quantity`) instead of applying a 10% discount to the total price (`total * 0.9`).
+
+**Business Logic:**
+The function should apply a 10% discount (pay 90%) when the total price exceeds $1000.
+
+**Fix Applied:**
+Changed:
+```python
+# Before (buggy):
+return (price * 0.5) * quantity
+
+# After (fixed):
+return total * 0.9
+```
+
+**PR Link:** https://github.com/s0l0l0b0/demo-agent-project/pull/2


### PR DESCRIPTION
## Summary
Fixes the incorrect discount calculation logic in `calculate_discount` function.

## Problem
The function was applying a 50% discount (multiplying by 0.5) to the unit price, instead of applying a 10% discount (multiplying by 0.9) to the total price.

## Solution
Changed:
- `return (price * 0.5) * quantity` (50% discount on unit price)
- To: `return total * 0.9` (10% discount on total)

This correctly applies the 10% discount to the total when it exceeds $1000.

Fixes #1