### PR TITLE
fix: Handle empty list in get_average_score to avoid ZeroDivisionError

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,8 @@ def get_average_score(scores):
     Calculates the average of a list of scores.
     Bug: Does not handle empty lists, will throw ZeroDivisionError.
     """
+    if len(scores) == 0:
+        return 0
     return sum(scores) / len(scores)
 
 def format_username(first_name, last_name):


### PR DESCRIPTION
## Summary
Fixes the ZeroDivisionError in `get_average_score` function when an empty list is provided.

## Problem
The function crashes with ZeroDivisionError when passed an empty list.

## Solution
Added a guard clause to check if the list is empty and return 0 in that case.

Fixes #3