### PR TITLE
fix: Remove trailing space in format_username when last_name is empty

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,7 +21,9 @@ def format_username(first_name, last_name):
     Formats a full name.
     Bug: If last_name is empty string, it leaves a trailing space.
     """
-    return f"{first_name} {last_name}"
+    if last_name:
+        return f"{first_name} {last_name}"
+    return first_name
 
 def main():
     print("Hello from demo-agent-project!")


### PR DESCRIPTION
## Summary
Fixes the trailing space issue in `format_username` function when last_name is empty.

## Problem
The function returns "{first_name} " (with trailing space) when last_name is an empty string.

## Solution
Added a conditional check: if last_name is truthy, include it with proper spacing; otherwise return just first_name.

Fixes #4